### PR TITLE
Fix cppref; add cref

### DIFF
--- a/src/cogs/cpp.py
+++ b/src/cogs/cpp.py
@@ -57,12 +57,12 @@ class cpp(commands.Cog, name="C++"):
                 f"[`std::{q}`](http://en.cppreference.com/w/cpp/{q})")
 
         for _, result in enumerate(results):
+            result = result.replace("src/cppref/", "")
             check_name = result.replace(
                 "http://en.cppreference.com/w/", "")
             check_name = check_name.replace("\\", "/")
             # print(check_name)
 
-            check_name = check_name.replace("src/cppref/cpp/", "")
             # print(check_name)
             f_name = check_name.replace("/", "::")
             f_name = f_name.replace(".html", "")
@@ -112,6 +112,7 @@ class cpp(commands.Cog, name="C++"):
                 f"[`{query}`](http://en.cppreference.com/w/c/{query})")
 
         for _, result in enumerate(results):
+            result = result.replace("src/cppref/", "")
             check_name = result.replace("http://en.cppreference.com/w/", "")
 
             check_name = check_name.replace(
@@ -119,7 +120,6 @@ class cpp(commands.Cog, name="C++"):
             # print(check_name)
 
             f_name = check_name.replace(".html", "")
-            f_name = f_name.replace("src/cppref/c/", "")
 
             if check_name.startswith(("language", "concept")) and not check_name.startswith("concepts"):
                 special_pages.append(

--- a/src/cogs/cpp.py
+++ b/src/cogs/cpp.py
@@ -14,32 +14,35 @@ class cpp(commands.Cog, name="C++"):
         self.bot = bot
 
     def get_directory_files(self, query, directory):
-        for file in glob.iglob(f"{directory}/*"):
+        for file in glob.iglob(f"{directory}/*", recursive=True):
             if not query.lower() in file.lower():
                 continue
-            yield f"http://en.cppreference.com/w/{file[2:]}"
+            yield f'http://en.cppreference.com/w/{file.replace("/src/cppref", "")}'
             if not os.path.isdir(file):
                 continue
             yield from self.get_directory_files(query, file)
 
-    def get_corresponding_files(self, query):
+    def get_corresponding_files(self, query: str, language: str):
         if query.startswith("std::"):
             query = query.replace("std::", "")
+
         query = query.replace("::", "/")
         output = []
-        to_queue = list(self.get_directory_files(query, "src/cppref/cpp/**"))
+        to_queue = list(self.get_directory_files(
+            query, f"src/cppref/{language}/**"))
         for index, each in enumerate(to_queue):
             if each.endswith(".html"):
                 continue
             output.append(
                 to_queue.pop(index))
+
         output.extend(to_queue)
         return output
 
     @commands.command()
     async def cppref(self, ctx, *, query: str):
         """Search something on cppreference"""
-        results = self.get_corresponding_files(query)
+        results = self.get_corresponding_files(query, "cpp")
 
         url = f'http://en.cppreference.com/w/cpp/index.php?title=Special:Search?search={query}'
 
@@ -48,42 +51,101 @@ class cpp(commands.Cog, name="C++"):
         special_pages = []
         description = []
         q = query.replace('std::', '')
+
         if os.path.isdir(f"src/cppref/cpp/{q}"):
             description.append(
                 f"[`std::{q}`](http://en.cppreference.com/w/cpp/{q})")
+
         for _, result in enumerate(results):
-            check_name = result.replace("http://en.cppreference.com/", "")
-            if check_name.startswith("src/cppref/cpp/container"):
-                check_name = check_name[:5] + check_name[15:]
-            if check_name.startswith("src/cppref/cpp/algorithm"):
-                check_name = check_name[:5] + check_name[15:]
-            if check_name.startswith("src/cppref/cpp/memory"):
-                check_name = check_name[:5] + check_name[12:]
-            f_name = check_name[6:].replace("\\", "::").replace(".html", "")
-            if check_name.startswith(("src/cppref/cpp/language", "src/cppref/cpp/concept")):
+            check_name = result.replace(
+                "http://en.cppreference.com/w/", "")
+            check_name = check_name.replace("\\", "/")
+            # print(check_name)
+
+            check_name = check_name.replace("src/cppref/cpp/", "")
+            # print(check_name)
+            f_name = check_name.replace("/", "::")
+            f_name = f_name.replace(".html", "")
+
+            if check_name.startswith(("language", "concept")) and not check_name.startswith("concepts"):
                 special_pages.append(
-                    f'[`{f_name.replace("/", "::")}`]({result})')
+                    f'[`{f_name}`]({result})')
                 continue
 
             description.append(
-                f'[`std::{f_name.replace("/", "::")}`]({result})')
+                f'[`std::{f_name}`]({result})')
 
         if len(special_pages) > 0:
             e.add_field(name='Language Results', value='\n'.join(
-                special_pages), inline=False)
+                special_pages))
             if len(description):
                 e.add_field(name='Library Results', value='\n'.join(
-                    description[:10]), inline=False)
+                    description[:10]))
         else:
             if not len(description):
-                return await ctx.send('No results found.')
+                return print('No results found.')
 
             desc_str = '\n'.join(description[:15])
             e.title = 'Search Results'
-            e.description = desc_str
+            e.desc = desc_str
 
-        e.add_field(
-            name='See More', value=f'[`{discord.utils.escape_markdown(query)}` results]({url})')
+            e.add_field(name='See More',
+                        value=f'[`{discord.utils.escape_markdown(query)}` results]({url})')
+
+        await ctx.send(embed=e)
+
+    @commands.command()
+    async def cref(self, ctx, *, query: str):
+        """Search something on cppreference"""
+        results = self.get_corresponding_files(query, "c")
+
+        url = f'http://en.cppreference.com/w/c/index.php?title=Special:Search?search={query}'
+
+        e = discord.Embed()
+
+        special_pages = []
+        description = []
+
+        # No need to replace std:: with "" since this is a c reference search
+        if os.path.isdir(f"src/cppref/c/{query}"):
+            description.append(
+                f"[`{query}`](http://en.cppreference.com/w/c/{query})")
+
+        for _, result in enumerate(results):
+            check_name = result.replace("http://en.cppreference.com/w/", "")
+
+            check_name = check_name.replace(
+                "\\", "/")
+            # print(check_name)
+
+            f_name = check_name.replace(".html", "")
+            f_name = f_name.replace("src/cppref/c/", "")
+
+            if check_name.startswith(("language", "concept")) and not check_name.startswith("concepts"):
+                special_pages.append(
+                    f'[`{f_name}`]({result})')
+                continue
+
+            description.append(
+                f'[`{f_name}`]({result})')
+
+        if len(special_pages) > 0:
+            e.add_field(name='Language Results', value='\n'.join(
+                special_pages))
+            if len(description):
+                e.add_field(name='Library Results', value='\n'.join(
+                    description[:10]))
+        else:
+            if not len(description):
+                return print('No results found.')
+
+            desc_str = '\n'.join(description[:15])
+            e.title = 'Search Results'
+            e.desc = desc_str
+
+            e.add_field(name='See More',
+                        value=f'[`{discord.utils.escape_markdown(query)}` results]({url})')
+
         await ctx.send(embed=e)
 
     @commands.command()


### PR DESCRIPTION
This should (hopefully) fix the `cppref` command and add a `cref` command to only look for C and not C++ stuff. I did not use a bot to test this, I used [this test I made](https://github.com/SqueakyBeaver/Better-C-Bot-Tests/blob/master/tests/cppref.py) which (more or less) prints the same thing on the console.

I do not claim to know what this code does, it just works I think.