### PR TITLE
Fix broken/missing reset after no admin reaction

### DIFF
--- a/src/backend/database.json
+++ b/src/backend/database.json
@@ -8,6 +8,8 @@
     "massjoin_min_acc_age": true,
     "massjoin_min_acc_age_val": 604800,
     "max_msg_size": 2000,
+    "no_react": "❎",
+    "yes_react": "✅",
     "permitted": [
         553478921870508061
     ],

--- a/src/cogs/rules.py
+++ b/src/cogs/rules.py
@@ -81,70 +81,73 @@ class RulesEnforcer(commands.Cog, name="Rules"):
         join_amount = len(self._recent_joins)
 
         if join_amount >= self.file["massjoin_amount"] and not self.massjoin_active:
-            self.massjoin_active = True
+            try:
+                self.massjoin_active = True
 
-            msg = await self._notify_staff(member.guild,
-                    f"Mass member join detected. React with {self.file['yes_react']} to take action or with {self.file['no_react']} to ignore")
+                msg = await self._notify_staff(member.guild,
+                    f"Mass member join detected. React with {self.file['yes_react']} to take action "
+                    + "or with {self.file['no_react']} to ignore")
 
-            await msg.add_reaction(self.file["no_react"])
-            await msg.add_reaction(self.file["yes_react"])
+                await msg.add_reaction(self.file["no_react"])
+                await msg.add_reaction(self.file["yes_react"])
 
-            def _check(reaction, user, reaction_msg):
-                return ( reaction.message.id == reaction_msg.id
+                def _check(reaction, user, reaction_msg):
+                    return ( reaction.message.id == reaction_msg.id
                         and any(role.id == self.file["staff_role"] for role in user.roles)
                         and user.id != self.bot.user.id )
 
-            reaction, user = await self.bot.wait_for('reaction_add',
+                reaction, user = await self.bot.wait_for('reaction_add',
                     check=lambda reaction, user: _check(reaction, user, msg),
                     timeout=self.file["massjoin_notif_timeout"])
 
-            if reaction.emoji == self.file["no_react"]:
-                await msg.reply("Not taking any action and resetting the join detection")
+                if reaction.emoji == self.file["no_react"]:
+                    await msg.reply("Not taking any action and resetting the join detection")
 
-            if reaction.emoji == self.file["yes_react"]:
-                wizard_msg = ( "Users assumed to be bots:\n" + ",\n".join(map(lambda x: f"<@{x['id']}>",
-                    filter(lambda x: x["assumed_bot"], self._recent_joins)))
-                    + "\nUsers assumed to not be bots:\n" + ",\n".join(map(lambda x: f"<@{x['id']}>",
-                    filter(lambda x: not x["assumed_bot"], self._recent_joins))) )
+                if reaction.emoji == self.file["yes_react"]:
+                    wizard_msg = ( "Users assumed to be bots:\n" + ",\n".join(map(lambda x: f"<@{x['id']}>",
+                        filter(lambda x: x["assumed_bot"], self._recent_joins)))
+                        + "\nUsers assumed to not be bots:\n" + ",\n".join(map(lambda x: f"<@{x['id']}>",
+                        filter(lambda x: not x["assumed_bot"], self._recent_joins))) )
 
-                messages = []
-                while len(wizard_msg) > self.file["max_msg_size"]:
-                    chunk = wizard_msg[0:self.file["max_msg_size"]]
-                    end_index = chunk.rfind('\n')
-                    messages.append(chunk[0:end_index])
-                    wizard_msg = wizard_msg[end_index:]
+                    messages = []
+                    while len(wizard_msg) > self.file["max_msg_size"]:
+                        chunk = wizard_msg[0:self.file["max_msg_size"]]
+                        end_index = chunk.rfind('\n')
+                        messages.append(chunk[0:end_index])
+                        wizard_msg = wizard_msg[end_index:]
 
-                messages.append(wizard_msg)
+                    messages.append(wizard_msg)
 
-                reply = msg
-                for message in messages:
-                    reply = await reply.reply(message)
+                    reply = msg
+                    for message in messages:
+                        reply = await reply.reply(message)
 
-                await reply.add_reaction(self.file["no_react"])
-                await reply.add_reaction(self.file["yes_react"])
+                    await reply.add_reaction(self.file["no_react"])
+                    await reply.add_reaction(self.file["yes_react"])
 
-                reaction, user = await self.bot.wait_for('reaction_add',
+                    reaction, user = await self.bot.wait_for('reaction_add',
                         check=lambda reaction, user: _check(reaction, user, reply),
                         timeout=self.file["massjoin_wizard_timeout"])
 
-                if reaction.emoji == self.file["no_react"]:
-                    await reply.reply("Not banning any users and resetting the join detection")
+                    if reaction.emoji == self.file["no_react"]:
+                        await reply.reply("Not banning any users and resetting the join detection")
 
-                if reaction.emoji == self.file["yes_react"]:
-                    for user in self._recent_joins:
-                        if user["assumed_bot"]:
-                            await member.guild.ban(
+                    if reaction.emoji == self.file["yes_react"]:
+                        for user in self._recent_joins:
+                            if user["assumed_bot"]:
+                                await member.guild.ban(
                                     self.bot.get_user(user["id"]) if self.bot.get_user(user["id"])
                                         else await self.bot.fetch_user(user["id"]))
 
-                    await reply.reply("Banned the bots")
+                        await reply.reply("Banned the bots")
 
-                await reply.clear_reactions()
+                    await reply.clear_reactions()
 
-            await msg.clear_reactions()
+                await msg.clear_reactions()
 
-            self._recent_joins.clear()
-            self.massjoin_active = False
+            finally:
+                self._recent_joins.clear()
+                self.massjoin_active = False
 
 
     @commands.command()

--- a/src/cogs/rules.py
+++ b/src/cogs/rules.py
@@ -133,13 +133,20 @@ class RulesEnforcer(commands.Cog, name="Rules"):
                         await reply.reply("Not banning any users and resetting the join detection")
 
                     if reaction.emoji == self.file["yes_react"]:
-                        for user in self._recent_joins:
-                            if user["assumed_bot"]:
-                                await member.guild.ban(
-                                    self.bot.get_user(user["id"]) if self.bot.get_user(user["id"])
-                                        else await self.bot.fetch_user(user["id"]))
+                        bot_count = sum(1 for x in self._recent_joins if x['assumed_bot'])
+                        ban_start_msg = await reply.reply(f"Banning {bot_count} user[s]")
 
-                        await reply.reply("Banned the bots")
+                        try:
+                            for user in self._recent_joins:
+                                if user["assumed_bot"]:
+                                    await member.guild.ban(
+                                        self.bot.get_user(user["id"]) if self.bot.get_user(user["id"])
+                                            else await self.bot.fetch_user(user["id"]))
+                        except:
+                            await ban_start_msg.reply("Banning failed")
+
+                        else:
+                            await ban_start_msg.reply("Banned the bots")
 
                     await reply.clear_reactions()
 

--- a/src/cogs/rules.py
+++ b/src/cogs/rules.py
@@ -86,7 +86,7 @@ class RulesEnforcer(commands.Cog, name="Rules"):
 
                 msg = await self._notify_staff(member.guild,
                     f"Mass member join detected. React with {self.file['yes_react']} to take action "
-                    + "or with {self.file['no_react']} to ignore")
+                    + f"or with {self.file['no_react']} to ignore")
 
                 await msg.add_reaction(self.file["no_react"])
                 await msg.add_reaction(self.file["yes_react"])


### PR DESCRIPTION
Fix an issue in the massjoin detection where important reset/cleanup code
wouldn't be run, because `wait_for()` threw an exception since no admin reacted.
To combat this, a try...finally was added.

Fixes #31