### PR TITLE
Fix the broken help and code evaluation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.13.5
 
 RUN apk update \
     && apk add clang gcc \
-    python3 py3-pip py3-lxml py3-yarl py3-chardet py3-aiohttp py3-attrs 
+    python3 py3-pip py3-lxml py3-yarl py3-chardet py3-aiohttp py3-attrs
 
 RUN adduser -D bettercbot
 USER bettercbot
@@ -18,5 +18,6 @@ COPY --chown=bettercbot:bettercbot token.txt token.txt
 COPY --chown=bettercbot:bettercbot src/__main__.py src/__main__.py
 COPY --chown=bettercbot:bettercbot src/cogs src/cogs
 COPY --chown=bettercbot:bettercbot src/backend src/backend
+
 
 CMD ["python3", "-m", "src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-discord.py==1.6.0
-lxml==4.6.3
+discord.py
+lxml

--- a/src/backend/verona.py
+++ b/src/backend/verona.py
@@ -30,18 +30,19 @@ def get_output_path(num: int) -> str:
     return f"/opt/verona-bot/output/{num}.txt"
 
 
-async def run_container(
-    num: int, timeout_count: int = 30
-) -> tuple[bool, str,]:
-    container = docker_client.containers.run(
-        "yuhanuncitgez/verona-bot:latest",
-        f'/opt/verona-bot-scripts/run.sh "{num}"',
-        stdout=True,
-        stderr=True,
-        auto_remove=True,
-        detach=True,
-        volumes={"/opt/verona-bot": {"bind": "/opt/verona-bot", "mode": "rw"}},
-    )
+async def run_container(num: int, timeout_count: int = 30) -> (bool, str, ):
+    container = docker_client.containers.run("yuhanuncitgez/verona-bot:latest", f"/opt/verona-bot-scripts/run.sh \"{num}\"",
+                                             stdout=True,
+                                             stderr=True,
+                                             auto_remove=True,
+                                             detach=True,
+                                             volumes={
+                                                 "/opt/verona-bot": {
+                                                     "bind": "/opt/verona-bot",
+                                                     "mode": "rw"
+                                                 }
+                                             }
+                                             )
     output_path = get_output_path(num)
     for _ in range(timeout_count + 1):
         if os.path.isfile(output_path):

--- a/src/backend/verona.py
+++ b/src/backend/verona.py
@@ -30,19 +30,18 @@ def get_output_path(num: int) -> str:
     return f"/opt/verona-bot/output/{num}.txt"
 
 
-async def run_container(num: int, timeout_count: int = 30) -> (bool, str, ):
-    container = docker_client.containers.run("yuhanuncitgez/verona-bot:latest", f"/opt/verona-bot-scripts/run.sh \"{num}\"",
-                                             stdout=True,
-                                             stderr=True,
-                                             auto_remove=True,
-                                             detach=True,
-                                             volumes={
-                                                 "/opt/verona-bot": {
-                                                     "bind": "/opt/verona-bot",
-                                                     "mode": "rw"
-                                                 }
-                                             }
-                                             )
+async def run_container(
+    num: int, timeout_count: int = 30
+) -> tuple[bool, str,]:
+    container = docker_client.containers.run(
+        "yuhanuncitgez/verona-bot:latest",
+        f'/opt/verona-bot-scripts/run.sh "{num}"',
+        stdout=True,
+        stderr=True,
+        auto_remove=True,
+        detach=True,
+        volumes={"/opt/verona-bot": {"bind": "/opt/verona-bot", "mode": "rw"}},
+    )
     output_path = get_output_path(num)
     for _ in range(timeout_count + 1):
         if os.path.isfile(output_path):

--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -33,7 +33,6 @@ class Administration(commands.Cog, name="Administration"):
         return content.strip("` \n")
 
     @commands.command(hidden=True)
-    @commands.is_owner()
     async def reload(self, ctx):
         """
         ReLoads all cogs.
@@ -49,7 +48,6 @@ class Administration(commands.Cog, name="Administration"):
         )
 
     @commands.command(hidden=True)
-    @commands.is_owner()
     async def eval(self, ctx, *, body: str):
         """
         Evaluates some code

--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -26,9 +26,16 @@ class Administration(commands.Cog, name="Administration"):
         return content.strip('` \n')
 
     @commands.command(hidden=True)
+    @commands.is_owner()
     async def reload(self, ctx):
-        if ctx.message.author.id not in self.file["permitted"]:
-            return await ctx.send("You do not have authorization to use this command")
+        """
+        ReLoads all cogs.
+        """
+        # Atm the only person in the permitted array is the owner, so instead of doing
+        # The below, we'll just use the built-in is_owner() check since it's also easier to test these
+
+        # if ctx.message.author.id not in self.file["permitted"]:
+        #     return await ctx.send("You do not have authorization to use this command")
 
         for cog in self.bot.user_cogs:
             self.bot.reload_extension(cog)
@@ -36,10 +43,13 @@ class Administration(commands.Cog, name="Administration"):
         await ctx.send("Updated cogs:\n```\n{}\n```".format('\n'.join(self.bot.user_cogs)))
 
     @commands.command(hidden=True)
+    @commands.is_owner()
     async def eval(self, ctx, *, body: str):
-        """Evaluates code"""
-        if ctx.message.author.id not in self.file["permitted"]:
-            return await ctx.send("You do not have authorization to use this command")
+        """
+        Evaluates some code
+        """
+        # if ctx.message.author.id not in self.file["permitted"]:
+        #     return await ctx.send("You do not have authorization to use this command")
 
         env = {
             'bot': self.bot,

--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -13,17 +13,24 @@ class Administration(commands.Cog, name="Administration"):
         self.bot = bot
         self._last_result = None
 
-        with open("src/backend/database.json", 'r') as file:
+        with open("src/backend/database.json", "r") as file:
             self.file = json.load(file)
 
     def cleanup_code(self, content):
         """Automatically removes code blocks from the code."""
+        content = (
+            content.replace("```", "\n```") # Prevents the last line being cut off
+            .replace("'", "\'") # ' -> \'
+            .replace('"', '\"') # " -> \"
+            .strip() # Remove trailing whitespace
+        )
+
         # remove ```py\n```
-        if content.startswith('```') and content.endswith('```'):
-            return '\n'.join(content.split('\n')[1:-1])
+        if content.startswith("```") and content.endswith("```"):
+            return "\n".join(content.split("\n")[1:-1])
 
         # remove `foo`
-        return content.strip('` \n')
+        return content.strip("` \n")
 
     @commands.command(hidden=True)
     @commands.is_owner()
@@ -40,7 +47,9 @@ class Administration(commands.Cog, name="Administration"):
         for cog in self.bot.user_cogs:
             self.bot.reload_extension(cog)
 
-        await ctx.send("Updated cogs:\n```\n{}\n```".format('\n'.join(self.bot.user_cogs)))
+        await ctx.send(
+            "Updated cogs:\n```\n{}\n```".format("\n".join(self.bot.user_cogs))
+        )
 
     @commands.command(hidden=True)
     @commands.is_owner()
@@ -52,13 +61,13 @@ class Administration(commands.Cog, name="Administration"):
         #     return await ctx.send("You do not have authorization to use this command")
 
         env = {
-            'bot': self.bot,
-            'ctx': ctx,
-            'channel': ctx.channel,
-            'author': ctx.author,
-            'guild': ctx.guild,
-            'message': ctx.message,
-            '_': self._last_result
+            "bot": self.bot,
+            "ctx": ctx,
+            "channel": ctx.channel,
+            "author": ctx.author,
+            "guild": ctx.guild,
+            "message": ctx.message,
+            "_": self._last_result,
         }
 
         env.update(globals())
@@ -71,28 +80,28 @@ class Administration(commands.Cog, name="Administration"):
         try:
             exec(to_compile, env)
         except Exception as e:
-            return await ctx.send(f'```py\n{e.__class__.__name__}: {e}\n```')
+            return await ctx.send(f"```py\n{e.__class__.__name__}: {e}\n```")
 
-        func = env['func']
+        func = env["func"]
         try:
             with redirect_stdout(stdout):
                 ret = await func()
         except Exception as e:
             value = stdout.getvalue()
-            await ctx.send(f'```py\n{value}{traceback.format_exc()}\n```')
+            await ctx.send(f"```py\n{value}{traceback.format_exc()}\n```")
         else:
             value = stdout.getvalue()
             try:
-                await ctx.message.add_reaction('\u2705')
+                await ctx.message.add_reaction("\u2705")
             except:
                 pass
 
             if ret is None:
                 if value:
-                    await ctx.send(f'```py\n{value}\n```')
+                    await ctx.send(f"```py\n{value}\n```")
             else:
                 self._last_result = ret
-                await ctx.send(f'```py\n{value}{ret}\n```')
+                await ctx.send(f"```py\n{value}{ret}\n```")
 
 
 def setup(bot):

--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -38,11 +38,8 @@ class Administration(commands.Cog, name="Administration"):
         """
         ReLoads all cogs.
         """
-        # Atm the only person in the permitted array is the owner, so instead of doing
-        # The below, we'll just use the built-in is_owner() check since it's also easier to test these
-
-        # if ctx.message.author.id not in self.file["permitted"]:
-        #     return await ctx.send("You do not have authorization to use this command")
+        if ctx.message.author.id not in self.file["permitted"]:
+            return await ctx.send("You do not have authorization to use this command")
 
         for cog in self.bot.user_cogs:
             self.bot.reload_extension(cog)
@@ -57,8 +54,8 @@ class Administration(commands.Cog, name="Administration"):
         """
         Evaluates some code
         """
-        # if ctx.message.author.id not in self.file["permitted"]:
-        #     return await ctx.send("You do not have authorization to use this command")
+        if ctx.message.author.id not in self.file["permitted"]:
+            return await ctx.send("You do not have authorization to use this command")
 
         env = {
             "bot": self.bot,

--- a/src/cogs/auto_mod.py
+++ b/src/cogs/auto_mod.py
@@ -36,6 +36,14 @@ class AutoMod(commands.Cog):
                 continue
 
             async for candidate in channel.history(limit=10):
+                if candidate.author != message.author:
+                    continue
+
+                # if the message has the same attachments, we probably don't need to check the text
+                if message.attachments == candidate.attachments:
+                    return True, candidate
+
+
                 if (
                     SequenceMatcher(None, message.content, candidate.content).ratio()
                     > self.database["dupe_thresh"]

--- a/src/cogs/auto_mod.py
+++ b/src/cogs/auto_mod.py
@@ -16,7 +16,7 @@ class AutoMod(commands.Cog):
         self.read_words()
 
         with open("src/backend/database.json") as file:
-            self.database = json.load(file)
+            self.file = json.load(file)
 
     def read_words(self):
         with open("badwords.txt") as file:
@@ -35,19 +35,30 @@ class AutoMod(commands.Cog):
             if channel == message.channel:
                 continue
 
-            async for candidate in channel.history(limit=10):
+            async for candidate in channel.history(limit=30):
                 if candidate.author != message.author:
                     continue
 
-                # if the message has the same attachments, we probably don't need to check the text
-                if message.attachments == candidate.attachments:
-                    return True, candidate
+                # if sent more than 12 hours ago, ignore it, it's probably fine
+                if (
+                    message.created_at.timestamp() - candidate.created_at.timestamp()
+                    > 3600 * 12
+                ):
+                    continue
 
+                # if the message has the same attachments, we probably don't need to check the text
+                if message.attachments and message.attachments == candidate.attachments:
+                    return True, candidate
 
                 if (
                     SequenceMatcher(None, message.content, candidate.content).ratio()
-                    > self.database["dupe_thresh"]
+                    > self.file["dupe_thresh"]
                 ):
+                    # if the message was a command, we can just ignore it
+                    ctx = await self.bot.get_context(candidate)
+                    if ctx.command:
+                        continue
+
                     return True, candidate
 
         # To keep from getting errors
@@ -76,18 +87,20 @@ class AutoMod(commands.Cog):
 
     @commands.group(hidden=True, aliases=["duplication"])
     @commands.guild_only()
-    @commands.is_owner()
     async def duplicate(self, ctx):
         """
         Duplication detection options
         """
+        if ctx.message.author.id not in self.file["permitted"]:
+            return await ctx.send("You do not have authorization to use this command")
+
         if ctx.invoked_subcommand is None:
-            dupe_enabled = "enabled" if self.database["dupe_enabled"] else "disabled"
+            dupe_enabled = "enabled" if self.file["dupe_enabled"] else "disabled"
 
             e = discord.Embed(
                 title=f"Duplicate message detection",
                 description="__Options:__"
-                + f"►\n**thresh**\n- Current threshold: **{self.database['dupe_thresh']}**\n"
+                + f"►\n**thresh**\n- Current threshold: **{self.file['dupe_thresh']}**\n"
                 + f"►\n**toggle**\n- Currently **{dupe_enabled}**",
             )
             return await ctx.send(embed=e)
@@ -97,9 +110,9 @@ class AutoMod(commands.Cog):
         """
         Change the threshold for the duplication detection. Default is 0.8
         """
-        self.database["dupe_thresh"] = new_thresh
+        self.file["dupe_thresh"] = new_thresh
         with open("src/backend/database.json", "w+") as file:
-            json.dump(self.database, file)
+            json.dump(self.file, file)
 
         await ctx.reply(f"The new duplication match threshold is {new_thresh}")
 
@@ -108,29 +121,31 @@ class AutoMod(commands.Cog):
         """
         Toggle the duplication detection. On by default
         """
-        self.database["dupe_enabled"] = not self.database["dupe_enabled"]
+        self.file["dupe_enabled"] = not self.file["dupe_enabled"]
 
         with open("src/backend/database.json", "w+") as file:
-            json.dump(self.database, file, indent=4)
+            json.dump(self.file, file, indent=4)
 
-        new_enabled = "enabled" if self.database["dupe_enabled"] else "disabled"
+        new_enabled = "enabled" if self.file["dupe_enabled"] else "disabled"
         await ctx.reply(f"Duplicated message detection is now {new_enabled}")
 
     # Commented out because I will do spam detection later
     # @commands.group(hidden=True, aliases=["duplication"])
     # @commands.guild_only()
-    # @commands.is_owner()
     # async def spam(self, ctx):
     #     """
     #     Duplication detection options
     #     """
+    #     if ctx.message.author.id not in self.file["permitted"]:
+    #         return await ctx.send("You do not have authorization to use this command")
+    #
     #     if ctx.invoked_subcommand is None:
-    #         spam_enabled = "enabled" if self.database["spam_enabled"] else "disabled"
-
+    #         spam_enabled = "enabled" if self.file["spam_enabled"] else "disabled"
+    #
     #         e = discord.Embed(
     #             title=f"Spam message detection",
     #             description="__Options:__"
-    #             + f"►\n**thresh**\n- Current threshold: **{self.database['spam_thresh']}**\n"
+    #             + f"►\n**thresh**\n- Current threshold: **{self.file['spam_thresh']}**\n"
     #             + f"►\n**toggle**\n- Currently **{spam_enabled}**",
     #         )
     #         return await ctx.send(embed=e)
@@ -140,9 +155,9 @@ class AutoMod(commands.Cog):
     #     """
     #     Change the threshold for the spam detection. Default is 5
     #     """
-    #     self.database["spam_thresh"] = new_thresh
+    #     self.file["spam_thresh"] = new_thresh
     #     with open("src/backend/database.json", "w+") as file:
-    #         json.dump(self.database, file)
+    #         json.dump(self.file, file)
 
     #     await ctx.reply(f"The new spam match threshold is {new_thresh}")
 
@@ -151,12 +166,12 @@ class AutoMod(commands.Cog):
     #     """
     #     Toggle the spam detection. On by default
     #     """
-    #     self.database["spam_enabled"] = not self.database["spam_enabled"]
+    #     self.file["spam_enabled"] = not self.file["spam_enabled"]
 
     #     with open("src/backend/database.json", "w+") as file:
-    #         json.dump(self.database, file, indent=4)
+    #         json.dump(self.file, file, indent=4)
 
-    #     new_enabled = "enabled" if self.database["spam_enabled"] else "disabled"
+    #     new_enabled = "enabled" if self.file["spam_enabled"] else "disabled"
     #     await ctx.reply(f"Spam message detection is now {new_enabled}")
 
 

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -12,7 +12,8 @@ class Help(commands.Cog):
 
     def formatter(self, i, stack=1, ignore_hidden=False):
         for cmd in i:
-            if cmd.hidden and not ignore_hidden:
+            # If the command is hidden and we should ignore hidden commands, skip it.
+            if cmd.hidden and ignore_hidden:
                 continue
             line = '- ' + cmd.help.split("\n")[0] if cmd.help else ""
             yield "\u200b " * (stack*2) + f"►**{cmd}** {line}\n"


### PR DESCRIPTION
A few things changed with this.

1. Hidden commands will now show if you type `.help <command>` but will not show in the default help (just `.help`)
2. The commands that previously checked if someone was permitted (only JohnkaS was) now should use the `commands.is_owner()` check
3. Fixed the `.eval` command by changing how the code is cleaned up

Also, I think my formatter changed all the `'`s to `"`s because I don't remember purposefully changing that